### PR TITLE
透過処理を追加してテクスチャの反転を直した

### DIFF
--- a/SceneTitle.cpp
+++ b/SceneTitle.cpp
@@ -73,7 +73,7 @@ SceneTitle::SceneTitle()
 	pSpriteRenderer = ObjectManager::FindObjectWithName("UI.2")->GetComponent<SpriteRenderer>();
 	pTransform = ObjectManager::FindObjectWithName("UI.2")->GetComponent<Transform>();
 	pSpriteRenderer->LoadTexture("Assets/Texture/karizanki.png");	//2022/12/14 小栗大輝　テクスチャを変更
-	pSpriteRenderer->SetSize(300, 50);
+	pSpriteRenderer->SetSize(300, 80);
 	ObjectManager::FindObjectWithName("UI.2")->SetLayerNum(1);
 	pTransform->SetPosition({ 450.0f, 300.0f, 0.0f });
 }

--- a/SpriteRenderer.cpp
+++ b/SpriteRenderer.cpp
@@ -11,7 +11,19 @@ std::list<std::pair<std::string, ID3D11ShaderResourceView*>> SpriteRenderer::m_T
 // コンストラクタ
 SpriteRenderer::SpriteRenderer()
 {
-
+	//ブレンドステート作成
+	D3D11_RENDER_TARGET_BLEND_DESC blend = {};
+	blend.BlendEnable = true;	//ブレンドを行う設定
+	blend.RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+	blend.SrcBlend = D3D11_BLEND_SRC_ALPHA;
+	blend.DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+	blend.SrcBlendAlpha = D3D11_BLEND_ONE;
+	blend.DestBlendAlpha = D3D11_BLEND_ZERO;
+	blend.BlendOp = D3D11_BLEND_OP_ADD;
+	blend.BlendOpAlpha = D3D11_BLEND_OP_ADD;
+	m_pAlphaBlend = new BlendState();
+	m_pAlphaBlend->Create(blend);
+	m_pAlphaBlend->Bind();
 }
 
 // デストラクタ
@@ -140,10 +152,10 @@ void SpriteRenderer::End()
 void SpriteRenderer::SetSize(float width, float height)
 {
 	Vertex vtx[4] = {
-		{{-(width / 2), -(height / 2), 0.0f}, {0.0f, 0.0f}},
-		{{ (width / 2), -(height / 2), 0.0f}, {1.0f, 0.0f}},
-		{{-(width / 2),  (height / 2), 0.0f}, {0.0f, 1.0f}},
-		{{ (width / 2),  (height / 2), 0.0f}, {1.0f, 1.0f}} };
+		{{(width / 2), (height / 2), 0.0f}, {0.0f, 0.0f}},
+		{{-(width / 2), (height / 2), 0.0f}, {1.0f, 0.0f}},
+		{{(width / 2), -(height / 2), 0.0f}, {0.0f, 1.0f}},
+		{{ -(width / 2),  -(height / 2), 0.0f}, {1.0f, 1.0f}} };
 	m_SpriteInfo.pVtxBuf = new VertexBuffer;
 	m_SpriteInfo.pVtxBuf->Create(vtx, 4);
 }

--- a/SpriteRenderer.h
+++ b/SpriteRenderer.h
@@ -55,7 +55,7 @@ private:
 	static VertexShader* m_pDefVS;
 	static PixelShader* m_pDefPS;
 	static unsigned int m_shaderRef;
-	//static BlendState* m_pAlphaBlend;
+	BlendState* m_pAlphaBlend;		//static消した　小栗 12/15
 	// テクスチャリスト
 	static std::list<std::pair<std::string, ID3D11ShaderResourceView*>> m_TextureList;
 private:


### PR DESCRIPTION
vxtを反転させてテクスチャが反転するのをなおしたのと
透過処理を入れてみたんだけど、まだUIと重なった部分が一緒に透過されちゃう
タスケテ・・・